### PR TITLE
r-xml 3.99-0.17: build against libxml2 2.13 on linux-64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,5 +2,18 @@
 
 if [[ ${HOST} =~ .*darwin.* ]]; then
   export PKG_CPPFLAGS=-Wl,-rpath,${PREFIX}/lib
+  # 'Autobrew' is being used by more and more packages these days
+  # to grab static libraries from Homebrew bottles. These bottles
+  # are fetched via Homebrew's --force-bottle option which grabs
+  # a bottle for the build machine which may not be macOS 10.9.
+  # Also, we want to use conda packages (and shared libraries) for
+  # these 'system' dependencies. See:
+  # https://github.com/jeroen/autobrew/issues/3
+  export DISABLE_AUTOBREW=1
 fi
-$R CMD INSTALL --build .
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -va '^Priority: ' DESCRIPTION.old > DESCRIPTION
+# shellcheck disable=SC2086
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '3.99-0.14' %}
+{% set version = '3.99-0.17' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -11,7 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/XML_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/XML/XML_{{ version }}.tar.gz
-  sha256: 2cb6a61a4d8d89e311994f47df09913d4ce5281317d42c78af4aafd75a31f1f9
+  sha256: 6e233265ff69ff2f59f56fe4abc5af70e2cfa6d99aec6ad2afd2bf2c0d98a2d8
 
 build:
   merge_build_host: True  # [win]
@@ -72,15 +72,10 @@ about:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'
     - LICENSE
 
-extra:
-  recipe-maintainers:
-    - croth1
-    - mingwandroid
-
 # The original CRAN metadata for this package was:
 
 # Package: XML
-# Version: 3.99-0.14
+# Version: 3.99-0.17
 # Authors@R: c(person("CRAN Team", role = c('ctb', 'cre'), email = "CRAN@r-project.org", comment = "de facto maintainer since 2013"), person("Duncan", "Temple Lang", role = c("aut"), email = "duncan@r-project.org", comment = c(ORCID = "0000-0003-0159-1546")), person("Tomas", "Kalibera", role = "ctb"))
 # Title: Tools for Parsing and Generating XML Within R and S-Plus
 # Depends: R (>= 4.0.0), methods, utils
@@ -91,11 +86,11 @@ extra:
 # License: BSD_3_clause + file LICENSE
 # Collate: AAA.R DTD.R DTDClasses.R DTDRef.R SAXMethods.R XMLClasses.R applyDOM.R assignChild.R catalog.R createNode.R dynSupports.R error.R flatTree.R nodeAccessors.R parseDTD.R schema.R summary.R tangle.R toString.R tree.R version.R xmlErrorEnums.R xmlEventHandler.R xmlEventParse.R xmlHandler.R xmlInternalSource.R xmlOutputDOM.R xmlNodes.R xmlOutputBuffer.R xmlTree.R xmlTreeParse.R htmlParse.R hashTree.R zzz.R supports.R parser.R libxmlFeatures.R xmlString.R saveXML.R namespaces.R readHTMLTable.R reflection.R xmlToDataFrame.R bitList.R compare.R encoding.R fixNS.R xmlRoot.R serialize.R xmlMemoryMgmt.R keyValueDB.R solrDocs.R XMLRErrorInfo.R xincludes.R namespaceHandlers.R tangle1.R htmlLinks.R htmlLists.R getDependencies.R getRelativeURL.R xmlIncludes.R simplifyPath.R
 # NeedsCompilation: yes
-# Packaged: 2023-03-19 10:59:44 UTC; ripley
+# Packaged: 2024-06-25 12:03:40 UTC; hornik
 # Author: CRAN Team [ctb, cre] (de facto maintainer since 2013), Duncan Temple Lang [aut] (<https://orcid.org/0000-0003-0159-1546>), Tomas Kalibera [ctb]
 # Maintainer: CRAN Team <CRAN@r-project.org>
 # Repository: CRAN
-# Date/Publication: 2023-03-19 11:04:35 UTC
+# Date/Publication: 2024-06-25 13:05:01 UTC
 
 # See
 # https://docs.conda.io/projects/conda-build for


### PR DESCRIPTION
**Destination channel:** **r**

### Links

- [PKG-5051](https://anaconda.atlassian.net/browse/PKG-5051) 
- [Upstream repository](https://cran.r-project.org/web/packages/XML/index.html)

### Explanation of changes:

- Update the recipe by `conda skeleton`

### Notes:

- Updating against `libxml2 2.13` on **linux-64** only

[PKG-5051]: https://anaconda.atlassian.net/browse/PKG-5051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ